### PR TITLE
Implicitly become privileged. Only do actions if not installed. Optionally upgrade npm.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for antonchernik.nodejs
+npm_upgrade: 'true'
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,34 @@
 ---
+- name: check if nodejs is installed
+  package:
+    name: nodejs
+    state: present
+  check_mode: true
+  register: nodejs_package_check
+  tags: nodejs
+
 - name: Nodejs ROLE | Download setup_8.x
   get_url:
     url: https://deb.nodesource.com/setup_8.x
     dest: /tmp/setup_8.x.sh
     mode: 0777
+  when: nodejs_package_check.changed
+  tags: nodejs
 
 - name: Nodejs ROLE | Run setup_8.x.sh
   shell: bash setup_8.x.sh
   args:
     chdir: /tmp/
   become: yes
+  when: nodejs_package_check.changed
+  tags: nodejs
 
 - name: Nodejs ROLE | Updating apt cache
   apt:
     update_cache: yes
   become: yes
+  when: nodejs_package_check.changed
+  tags: nodejs
 
 - name: Nodejs ROLE | Install packages
   apt: name={{item}}
@@ -25,16 +39,26 @@
     - libgif-dev
     - nodejs
   become: yes
+  when: nodejs_package_check.changed
+  tags: nodejs
 
 - name: Nodejs ROLE | Clean cache
   command: npm cache clean -f
   become: yes
+  when: nodejs_package_check.changed
+  tags: nodejs
 
 - name: Nodejs ROLE | Npm upgrade to latest version
   command: npm install npm@latest -g
   become: yes
+  when: npm_upgrade == 'true'
+  tags: nodejs
 
 - name: Nodejs ROLE | Install n package
-  command: npm install -g n
+  npm:
+   name: n
+   global: yes
   become: yes
+  tags: nodejs
+
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,12 @@
   shell: bash setup_8.x.sh
   args:
     chdir: /tmp/
+  become: yes
 
 - name: Nodejs ROLE | Updating apt cache
   apt:
     update_cache: yes
+  become: yes
 
 - name: Nodejs ROLE | Install packages
   apt: name={{item}}
@@ -22,12 +24,17 @@
     - libpango1.0-dev
     - libgif-dev
     - nodejs
+  become: yes
 
 - name: Nodejs ROLE | Clean cache
   command: npm cache clean -f
+  become: yes
 
 - name: Nodejs ROLE | Npm upgrade to latest version
   command: npm install npm@latest -g
+  become: yes
 
 - name: Nodejs ROLE | Install n package
   command: npm install -g n
+  become: yes
+


### PR DESCRIPTION
There are some cases where we want to be able to run this role using include_role on a potentially unprivileged execution. This pull request implicitly adds become: yes to tasks requiring root privileges.

Historically ansible passed through become: yes when doing include_role but this is no longer the case. See: https://github.com/ansible/ansible/issues/29159

Commit be85066077aeac046068c2614465ed6f00ef5413 adds the following:
1) Don't attempt package install if nodejs package is already deployed (avoids pointless cycling)
2) Don't attempt to upgrade npm to latest version. Latest npm is actually buggy (https://github.com/npm/npm/issues/19989) so currently we deploy successfully then kill our install.
3) Add nodejs tags, useful for include_role uses
